### PR TITLE
Add CSV import/export test suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@babel/preset-env": "^7.28.0"
+        "@babel/preset-env": "^7.28.0",
+        "sql.js": "^1.13.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -74,6 +75,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2047,6 +2049,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2120,7 +2123,6 @@
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
       "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hammerjs": "^2.0.36"
       },
@@ -3032,6 +3034,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.28.tgz",
       "integrity": "sha512-d1QDn+KNHfHGt3UIwOZvupvdsDdiHYZBEj7+wL2yDVo3tMezamYy60H9s3EnNVE1Ae1ty0trc7F2OKqo/RmsdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.14.0",
         "escape-string-regexp": "^4.0.0",
@@ -3156,8 +3159,7 @@
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
       "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -3738,6 +3740,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4386,6 +4389,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -4840,6 +4844,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -5251,7 +5256,6 @@
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -5260,8 +5264,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -7289,6 +7292,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7308,6 +7312,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7338,6 +7343,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -7465,6 +7471,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -7475,6 +7482,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -7490,6 +7498,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -7618,6 +7627,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8142,6 +8152,13 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/sql.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.13.0.tgz",
+      "integrity": "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -8519,6 +8536,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "test": "node src/__tests__/simple-test.js"
+    "test": "node src/__tests__/Add_tree_test.js",
+    "test:csv": "node src/__tests__/CSV_import_export_test.mjs"
   },
   "dependencies": {
     "@react-native-community/slider": "^5.1.2",
@@ -31,6 +32,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.28.0"
+    "@babel/preset-env": "^7.28.0",
+    "sql.js": "^1.13.0"
   }
 }

--- a/src/__tests__/CSV_import_export_test.mjs
+++ b/src/__tests__/CSV_import_export_test.mjs
@@ -1,0 +1,215 @@
+/**
+ * CSV Import/Export Tests (ESM version)
+ * Run: node src/__tests__/CSV_import_export_test.mjs
+ * Verbose (log all errors/warnings): VERBOSE=1 npm run test:csv
+ */
+
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import initSqlJs from 'sql.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Dynamic import for csvParser (ES module)
+const { parseTreeCSV } = await import('../utils/csvParser.js');
+
+const SAMPLE_CSV = path.join(__dirname, '../../test-data/sample_trees.csv');
+const SAMPLE_ERRORS_CSV = path.join(__dirname, '../../test-data/sample_trees_with_errors.csv');
+
+const VERBOSE = process.env.VERBOSE === '1' || process.argv.includes('--verbose');
+
+function logParseResult(label, result) {
+  if (result.errors.length > 0) {
+    console.error(`   [${label}] Parsing errors:`);
+    result.errors.forEach((e, i) => {
+      console.error(`     ${i + 1}. Row ${e.row}: ${e.message}${e.treeId ? ` (tree_id: ${e.treeId})` : ''}`);
+    });
+  }
+  if (result.warnings && result.warnings.length > 0) {
+    console.warn(`   [${label}] Warnings:`);
+    result.warnings.forEach((w, i) => {
+      console.warn(`     ${i + 1}. Row ${w.row} (${w.treeId}): ${w.message}`);
+    });
+  }
+}
+
+function logImportResult(label, result) {
+  if (result.errors.length > 0) {
+    console.error(`   [${label}] Import errors:`);
+    result.errors.forEach((e, i) => {
+      console.error(`     ${i + 1}. ${e.tree_id}: ${e.message}`);
+    });
+  }
+  if (result.duplicates.length > 0) {
+    console.warn(`   [${label}] Duplicates skipped: ${result.duplicates.map((d) => d.tree_id).join(', ')}`);
+  }
+}
+
+console.log('Running CSV Import/Export Tests...\n');
+
+async function createTestDatabase() {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  db.run(`
+    CREATE TABLE trees (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      tree_id TEXT UNIQUE NOT NULL,
+      date TEXT NOT NULL,
+      northing REAL NOT NULL,
+      easting REAL NOT NULL,
+      species TEXT NOT NULL,
+      dbh REAL,
+      tree_height REAL NOT NULL,
+      crown_height REAL,
+      crown_radius REAL,
+      crown_completeness REAL,
+      tags TEXT,
+      synced INTEGER DEFAULT 0,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE INDEX idx_trees_tree_id ON trees(tree_id);
+  `);
+  return db;
+}
+
+function importTreesToTestDb(db, trees) {
+  const results = { success: 0, errors: [], duplicates: [], skipped: 0 };
+  const existingStmt = db.prepare('SELECT tree_id FROM trees');
+  const existingIds = new Set();
+  while (existingStmt.step()) existingIds.add(existingStmt.get()[0]);
+  existingStmt.free();
+
+  const insertStmt = db.prepare(`
+    INSERT INTO trees (tree_id, date, northing, easting, species, dbh,
+      tree_height, crown_height, crown_radius, crown_completeness, tags, synced)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  for (const tree of trees) {
+    if (existingIds.has(tree.tree_id)) {
+      results.duplicates.push({ tree_id: tree.tree_id, message: 'Duplicate' });
+      results.skipped++;
+      continue;
+    }
+    try {
+      insertStmt.run([
+        tree.tree_id, tree.date, tree.northing, tree.easting, tree.species,
+        tree.dbh ?? null, tree.tree_height, tree.crown_height ?? null,
+        tree.crown_radius ?? null, tree.crown_completeness ?? null,
+        tree.tags ?? null, 0,
+      ]);
+      results.success++;
+      existingIds.add(tree.tree_id);
+    } catch (err) {
+      results.errors.push({ tree_id: tree.tree_id, message: err.message });
+    }
+  }
+  insertStmt.free();
+  return results;
+}
+
+function getAllTreesFromTestDb(db) {
+  const stmt = db.prepare('SELECT * FROM trees ORDER BY created_at DESC');
+  const trees = [];
+  while (stmt.step()) trees.push(stmt.getAsObject());
+  stmt.free();
+  return trees;
+}
+
+function exportToCSVFromTestDb(db) {
+  const trees = getAllTreesFromTestDb(db);
+  let csv = 'Tree ID,Date,Northing,Easting,Species,DBH,Height,Crown height,Crown radius,Crown completeness,Tags\n';
+  trees.forEach((t) => {
+    csv += `${t.tree_id},${t.date},${t.northing},${t.easting},${t.species},${t.dbh ?? ''},${t.tree_height},${t.crown_height ?? ''},${t.crown_radius ?? ''},${t.crown_completeness ?? ''},${t.tags ?? ''}\n`;
+  });
+  return csv;
+}
+
+async function runTests() {
+  let db;
+  let parseResult, importResult, reparseResult, errorsResult, errorsImportResult;
+  try {
+    console.log('Test 1: Parse valid CSV file');
+    const csvContent = fs.readFileSync(SAMPLE_CSV, 'utf-8');
+    parseResult = parseTreeCSV(csvContent);
+    if (VERBOSE || parseResult.errors.length > 0 || (parseResult.warnings && parseResult.warnings.length > 0)) {
+      logParseResult('Test 1', parseResult);
+    }
+    assert.ok(parseResult.trees.length > 0, 'Should parse at least one tree');
+    assert.ok(parseResult.errors.length === 0, 'Valid CSV should have no errors');
+    console.log(`   Parsed ${parseResult.trees.length} trees - PASS\n`);
+
+    console.log('Test 2: Import to database and verify map-ready data');
+    db = await createTestDatabase();
+    importResult = importTreesToTestDb(db, parseResult.trees);
+    if (VERBOSE || importResult.errors.length > 0 || importResult.duplicates.length > 0) {
+      logImportResult('Test 2', importResult);
+    }
+    assert.ok(importResult.success > 0, 'At least one tree should import');
+    assert.strictEqual(importResult.success + importResult.skipped, parseResult.trees.length, 'All trees accounted for (imported or duplicates)');
+    const allTrees = getAllTreesFromTestDb(db);
+    allTrees.forEach((tree) => {
+      assert.ok(tree.tree_id && tree.species, 'Map needs tree_id and species');
+      assert.ok(typeof tree.northing === 'number' && typeof tree.easting === 'number', 'Map needs coords');
+    });
+    console.log(`   Imported ${importResult.success} trees, map would show ${allTrees.length} markers - PASS\n`);
+
+    console.log('Test 3: Export to CSV and round-trip');
+    const exportedCsv = exportToCSVFromTestDb(db);
+    reparseResult = parseTreeCSV(exportedCsv);
+    if (VERBOSE || reparseResult.errors.length > 0 || (reparseResult.warnings && reparseResult.warnings.length > 0)) {
+      logParseResult('Test 3 (reparse)', reparseResult);
+    }
+    assert.strictEqual(reparseResult.trees.length, allTrees.length, 'Round-trip should preserve imported count');
+    console.log('   Export and round-trip valid - PASS\n');
+
+    console.log('Test 4: Parse CSV with errors (partial import)');
+    const errorsCsv = fs.readFileSync(SAMPLE_ERRORS_CSV, 'utf-8');
+    errorsResult = parseTreeCSV(errorsCsv);
+    if (VERBOSE || errorsResult.errors.length > 0 || (errorsResult.warnings && errorsResult.warnings.length > 0)) {
+      logParseResult('Test 4', errorsResult);
+    }
+    assert.ok(errorsResult.errors.length > 0 && errorsResult.trees.length > 0, 'Should have both errors and valid rows');
+    db = await createTestDatabase();
+    errorsImportResult = importTreesToTestDb(db, errorsResult.trees);
+    if (VERBOSE || errorsImportResult.errors.length > 0 || errorsImportResult.duplicates.length > 0) {
+      logImportResult('Test 4', errorsImportResult);
+    }
+    const mapTrees = getAllTreesFromTestDb(db);
+    assert.ok(mapTrees.length > 0, 'Map should show valid trees');
+    console.log(`   ${errorsResult.trees.length} valid imported, ${errorsResult.errors.length} errors - PASS\n`);
+
+    console.log('Test 5: Empty CSV handling');
+    assert.ok(parseTreeCSV('').errors.length > 0, 'Empty should error');
+    assert.strictEqual(parseTreeCSV('Tree ID,Date,Easting,Northing,Species,Height\n').trees.length, 0, 'Header-only = no trees');
+    console.log('   Empty/header-only handled - PASS\n');
+
+    console.log('All CSV import/export tests passed!\n');
+  } catch (error) {
+    console.error('\n--- TEST FAILED ---');
+    console.error('Message:', error.message);
+    console.error('Stack:', error.stack);
+    if (parseResult) {
+      console.error('\nParse result:', JSON.stringify({ treesCount: parseResult.trees?.length, errors: parseResult.errors, warnings: parseResult.warnings }, null, 2));
+    }
+    if (importResult !== undefined) {
+      console.error('\nImport result:', JSON.stringify(importResult, null, 2));
+    }
+    if (reparseResult !== undefined) {
+      console.error('\nReparse result:', JSON.stringify({ treesCount: reparseResult.trees?.length, errors: reparseResult.errors, warnings: reparseResult.warnings }, null, 2));
+    }
+    if (errorsResult !== undefined) {
+      console.error('\nErrors parse result:', JSON.stringify({ treesCount: errorsResult.trees?.length, errors: errorsResult.errors, warnings: errorsResult.warnings }, null, 2));
+    }
+    if (errorsImportResult !== undefined) {
+      console.error('\nErrors import result:', JSON.stringify(errorsImportResult, null, 2));
+    }
+    process.exit(1);
+  } finally {
+    if (db) db.close();
+  }
+}
+
+runTests();

--- a/src/utils/package.json
+++ b/src/utils/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/test-data/sample_trees.csv
+++ b/test-data/sample_trees.csv
@@ -1,4 +1,4 @@
-Tree ID,Date,Easting,Northing,Species,DBH,Height,Crown height,Crown radius,Crown completeness,Tags
+Tree ID,Date,Easting,Northing,Species,DBH,Height,Crown height,...
 acd4070d-8b4c-4f0d-9d8a-1b9843c10333,2024-07-30,1248801.6937619,6815478.1214491,Pinus,0.15,13,9.1,2,1,
 f2224073-532e-44a2-a3be-d8b48c0a0560,2024-07-30,1248808.9107414,6815478.0608269,Pinus,0.5,31,21.7,3.4,0.7,Bark Beetle
 baf16783-f2ba-480b-abb1-1c1e386fec99,2024-07-30,1248787.8258593,6815453.8528180,Pinus,6.501114121217194,30.31414384404,21.22270069122,3.371586095923,0,


### PR DESCRIPTION
Add CSV import/export test suite

- Add ESM test file (CSV_import_export_test.mjs) covering parse, import, export, and round-trip flows
- Test valid CSV parsing, DB import, and map-ready data validation
- Test export and round-trip (parse → import → export → reparse)
- Test partial import for CSVs with validation errors
- Test empty and header-only CSV handling
- Add test:csv npm script and sql.js devDependency
- Add src/utils/package.json for ESM compatibility
- Update sample_trees.csv test data